### PR TITLE
Fix cache error when append setting is disabled

### DIFF
--- a/addons/git_describe/settings.gd
+++ b/addons/git_describe/settings.gd
@@ -1,3 +1,4 @@
+@tool
 extends RefCounted
 
 const BASE = "addons/git_describe"


### PR DESCRIPTION
This error occurs on Godot 4.2 and earlier. It doesn't seem to stop things from working, but it's best not to have random errors during normal use.