### PR TITLE
Add macOS to platforms.cfg

### DIFF
--- a/addons/git_describe/platforms.cfg
+++ b/addons/git_describe/platforms.cfg
@@ -4,6 +4,12 @@ path="bash"
 arguments=["-c"]
 which="which"
 
+[macOS]
+
+path="bash"
+arguments=["-c"]
+which="which"
+
 [Steam Linux Runtime]
 
 ; https://gitlab.steamos.cloud/steamrt/steam-runtime-tools/-/blob/main/docs/slr-for-game-developers.md#running-commands-outside-the-container


### PR DESCRIPTION
Adding macOS support (the platform config is the same as the one that already exists for Linux).